### PR TITLE
Remove "--" if it exists in extra options

### DIFF
--- a/src/subcommands/arc_diff_against_parent.py
+++ b/src/subcommands/arc_diff_against_parent.py
@@ -28,6 +28,10 @@ class ArcDiffAgainstParent(BaseCommand):
         # type: (Namespace) -> None
         extra_arc_diff_options = args.arc_diff_args
         if extra_arc_diff_options:
+            # If the first extra arg starts with "-", "--" must also have been passed, and
+            # argparse doesn't remove it for us
+            if "--" in extra_arc_diff_options:
+                extra_arc_diff_options.remove("--")
             extra_args = " " + " ".join(extra_arc_diff_options)
         else:
             extra_args = ""

--- a/src/subcommands/arc_diff_against_parent.py
+++ b/src/subcommands/arc_diff_against_parent.py
@@ -30,8 +30,8 @@ class ArcDiffAgainstParent(BaseCommand):
         if extra_arc_diff_options:
             # If the first extra arg starts with "-", "--" must also have been passed, and
             # argparse doesn't remove it for us
-            if "--" in extra_arc_diff_options:
-                extra_arc_diff_options.remove("--")
+            if extra_arc_diff_options[0] == "--":
+                del extra_arc_diff_options[0]
             extra_args = " " + " ".join(extra_arc_diff_options)
         else:
             extra_args = ""

--- a/src/subcommands/arc_land_onto_parent.py
+++ b/src/subcommands/arc_land_onto_parent.py
@@ -29,8 +29,8 @@ class ArcLandOntoParent(BaseCommand):
         if extra_arc_land_options:
             # If the first extra arg starts with "-", "--" must also have been passed, and
             # argparse doesn't remove it for us
-            if "--" in extra_arc_land_options:
-                extra_arc_land_options.remove("--")
+            if extra_arc_land_options[0] == "--":
+                del extra_arc_land_options[0]
             extra_args = " " + " ".join(extra_arc_land_options)
         else:
             extra_args = ""

--- a/src/subcommands/arc_land_onto_parent.py
+++ b/src/subcommands/arc_land_onto_parent.py
@@ -27,6 +27,10 @@ class ArcLandOntoParent(BaseCommand):
         # type: (Namespace) -> None
         extra_arc_land_options = args.arc_land_args
         if extra_arc_land_options:
+            # If the first extra arg starts with "-", "--" must also have been passed, and
+            # argparse doesn't remove it for us
+            if "--" in extra_arc_land_options:
+                extra_arc_land_options.remove("--")
             extra_args = " " + " ".join(extra_arc_land_options)
         else:
             extra_args = ""


### PR DESCRIPTION
`argparse` doesn't remove `--` if it's passed, as it must be for `REMAINDER` args that start with `-`. This diff causes it to be removed if present before forwarding to `arc diff` or `arc land`, both of which choke on it otherwise. 