### PR TITLE
Add commands to clean up invalid branches and to delete all archived branches

### DIFF
--- a/bash_zsh_git_helper_aliases.sh
+++ b/bash_zsh_git_helper_aliases.sh
@@ -29,4 +29,8 @@ if [ -e "$GIT_CHILD_BRANCH_HELPERS_LOCATION" ]; then
     alias csa='"$GIT_CHILD_BRANCH_HELPERS_LOCATION" set-archived'
     # Print branch info
     alias cbi='"$GIT_CHILD_BRANCH_HELPERS_LOCATION" print-branch-info'
+    # Clean branches
+    alias ccb='"$GIT_CHILD_BRANCH_HELPERS_LOCATION" clean-branches'
+    # Delete archived
+    alias cda='"$GIT_CHILD_BRANCH_HELPERS_LOCATION" delete-archived'
 fi

--- a/src/git_helpers.py
+++ b/src/git_helpers.py
@@ -365,7 +365,18 @@ class BranchTracker(object):
         # type: (Text) -> bool
         return self._is_branch_archived[branch]
 
+    def is_branch_tracked(self, branch):
+        # type: (Text) -> bool
+        return branch in self._branch_to_bases.keys()
+
 
 def hash_for(rev):
     # type: (Text) -> Text
     return git("rev-parse --verify {}".format(rev)).strip()
+
+def does_branch_exist(branch_name):
+    # type: (Text) -> bool
+    command = "show-ref --verify --quiet refs/heads/{}".format(branch_name)
+    ret = run_command_expecting_failure(subprocess.call, "git", command)
+
+    return ret == 0

--- a/src/subcommands/__init__.py
+++ b/src/subcommands/__init__.py
@@ -9,6 +9,8 @@ from subcommands.git_rename_branch import GitRenameBranch
 from subcommands.print_branch_info import PrintBranchInfo
 from subcommands.print_child_branch_structure import PrintChildBranchStructure
 from subcommands.set_branch_archived import SetBranchArchived
+from subcommands.clean_branches import CleanBranches
+from subcommands.delete_archived_branches import DeleteArchivedBranches
 
 if False:
     from typing import Sequence, Set, Text
@@ -24,6 +26,8 @@ _ALL_COMMANDS = (
     PrintChildBranchStructure(),
     PrintBranchInfo(),
     SetBranchArchived(),
+    CleanBranches(),
+    DeleteArchivedBranches()
 )
 
 

--- a/src/subcommands/clean_branches.py
+++ b/src/subcommands/clean_branches.py
@@ -41,6 +41,7 @@ class CleanBranches(BaseCommand):
         # type: (Namespace) -> None
         clean_invalid_branches(args.archive)
 
+
 def clean_invalid_branches(archive):
     # type: (bool) -> None
     with get_branch_tracker() as tracker:
@@ -51,14 +52,17 @@ def clean_invalid_branches(archive):
                 else:
                     _delete_invalid_branch_if_possible(tracker, branch)
 
+
 def _is_branch_invalid(tracker, branch_name):
     # type: (BranchTracker, Text) -> bool
     return not does_branch_exist(branch_name) and not tracker.is_archived(branch_name)
+
 
 def _archive_invalid_branch(tracker, branch_name):
     # type: (BranchTracker, Text) -> None
     print("Archiving invalid branch {}".format(branch_name))
     tracker.set_is_archived(branch_name, True)
+
 
 def _delete_invalid_branch_if_possible(tracker, branch_name):
     # type: (BranchTracker, Text) -> None

--- a/src/subcommands/clean_branches.py
+++ b/src/subcommands/clean_branches.py
@@ -1,0 +1,86 @@
+# coding=utf-8
+from __future__ import print_function, unicode_literals
+
+import os
+import sys
+from argparse import ArgumentParser, Namespace
+
+from git_helpers import get_branch_tracker, get_current_branch, git, does_branch_exist, BranchTracker
+from subcommands.base_command import BaseCommand
+
+try:
+    # noinspection PyUnresolvedReferences
+    from typing import (
+        Iterable,
+        List,
+        Tuple,
+        TypeVar,
+        Text,
+    )
+
+    T = TypeVar('T')
+except ImportError:
+    pass
+
+from git_helpers import get_branch_tracker, get_current_branch, BranchTracker
+
+class CleanBranches(BaseCommand):
+    def get_name(self):
+        # type: () -> Text
+        return 'clean-branches'
+
+    def get_short_description(self):
+        # type: () -> Text
+        return 'deletes branches that are no longer known to git'
+
+    def inflate_subcommand_parser(self, parser):
+        # type: (ArgumentParser) -> None
+        parser.add_argument("-a", "--archive", action="store_true",
+                            help="set to archive instead of delete invalid branches")
+
+    def run_command(self, args):
+        # type: (Namespace) -> None
+        clean_invalid_branches(args.archive)
+
+def clean_invalid_branches(archive):
+    # type: (bool) -> None
+    with get_branch_tracker() as tracker:
+        roots = []
+        for parent in tracker.get_all_parents():
+            if not tracker.has_parent(parent):
+                roots.append(parent)
+
+        roots = sorted(roots)
+
+        for root in roots:
+            clean_invalid_branches_internal(tracker, root, archive)
+
+def clean_invalid_branches_internal(tracker, branch_name, archive):
+    # type: (BranchTracker, Text, bool) -> None
+    for child in tracker.children_for_parent(branch_name):
+        clean_invalid_branches_internal(tracker, child, archive)
+
+    if is_branch_invalid(tracker, branch_name):
+        if archive:
+            archive_invalid_branch(tracker, branch_name)
+        else:
+            delete_invalid_branch_if_possible(tracker, branch_name)
+
+def is_branch_invalid(tracker, branch_name):
+    # type: (BranchTracker, Text) -> bool
+    return not does_branch_exist(branch_name) and not tracker.is_archived(branch_name)
+
+def archive_invalid_branch(tracker, branch_name):
+    # type: (BranchTracker, Text) -> None
+    print("Archiving invalid branch {}".format(branch_name))
+    tracker.set_is_archived(branch_name, True)
+
+def delete_invalid_branch_if_possible(tracker, branch_name):
+    # type: (BranchTracker, Text) -> None
+    children = tracker.children_for_parent(branch_name)
+    if tracker.children_for_parent(branch_name):
+        error_message = "Cannot delete invalid branch {} because it has children ({}). Try rebasing its children on a valid branch first."
+        print(error_message.format(branch_name, children))
+    else:
+        print("Deleting invalid branch {}".format(branch_name))
+        tracker.remove_child_leaf(branch_name)

--- a/src/subcommands/delete_archived_branches.py
+++ b/src/subcommands/delete_archived_branches.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from __future__ import print_function, unicode_literals
 
 import os
@@ -45,24 +44,10 @@ class DeleteArchivedBranches(BaseCommand):
 def delete_archived_branches():
     # type: () -> None
     with get_branch_tracker() as tracker:
-        roots = []
-        for parent in tracker.get_all_parents():
-            if not tracker.has_parent(parent):
-                roots.append(parent)
-
-        roots = sorted(roots)
-
-        for root in roots:
-            delete_archived_branches_internal(tracker, root)
-
-def delete_archived_branches_internal(tracker, branch_name):
-    # type: (BranchTracker, Text) -> None
-    for child in tracker.children_for_parent(branch_name):
-        delete_archived_branches_internal(tracker, child)
-    
-    if tracker.is_branch_tracked(branch_name) and tracker.is_archived(branch_name):
-        if tracker.children_for_parent(branch_name):
-            print("Skipping deletion of archived branch {} because it has children".format(branch_name))
-        else:
-            print("Deleting {}".format(branch_name))
-            tracker.remove_child_leaf(branch_name)
+        for branch in tracker.list_of_branches():
+            if tracker.is_branch_tracked(branch) and tracker.is_archived(branch):
+                if tracker.children_for_parent(branch):
+                    print("Skipping deletion of archived branch {} because it has children".format(branch))
+                else:
+                    print("Deleting {}".format(branch))
+                    tracker.remove_child_leaf(branch)

--- a/src/subcommands/delete_archived_branches.py
+++ b/src/subcommands/delete_archived_branches.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+from __future__ import print_function, unicode_literals
+
+import os
+import sys
+from argparse import ArgumentParser, Namespace
+
+from git_helpers import get_branch_tracker, get_current_branch, git, does_branch_exist, hash_for
+from subcommands.base_command import BaseCommand
+
+try:
+    # noinspection PyUnresolvedReferences
+    from typing import (
+        Iterable,
+        List,
+        Tuple,
+        TypeVar,
+        Text,
+    )
+
+    T = TypeVar('T')
+except ImportError:
+    pass
+
+from git_helpers import get_branch_tracker, get_current_branch, BranchTracker
+
+class DeleteArchivedBranches(BaseCommand):
+    def get_name(self):
+        # type: () -> Text
+        return 'delete-archived'
+
+    def get_short_description(self):
+        # type: () -> Text
+        return 'deletes all archived branches'
+
+    def inflate_subcommand_parser(self, parser):
+        # type: (ArgumentParser) -> None
+        pass
+
+    def run_command(self, args):
+        # type: (Namespace) -> None
+        delete_archived_branches()
+
+
+def delete_archived_branches():
+    # type: () -> None
+    with get_branch_tracker() as tracker:
+        roots = []
+        for parent in tracker.get_all_parents():
+            if not tracker.has_parent(parent):
+                roots.append(parent)
+
+        roots = sorted(roots)
+
+        for root in roots:
+            delete_archived_branches_internal(tracker, root)
+
+def delete_archived_branches_internal(tracker, branch_name):
+    # type: (BranchTracker, Text) -> None
+    for child in tracker.children_for_parent(branch_name):
+        delete_archived_branches_internal(tracker, child)
+    
+    if tracker.is_branch_tracked(branch_name) and tracker.is_archived(branch_name):
+        if tracker.children_for_parent(branch_name):
+            print("Skipping deletion of archived branch {} because it has children".format(branch_name))
+        else:
+            print("Deleting {}".format(branch_name))
+            tracker.remove_child_leaf(branch_name)


### PR DESCRIPTION
This pull requests adds two commands:

**1) Clean up**
This command will delete (by default) or archive any branches that are no longer by Git. This is useful, when a command like `arc queue-cleanup` is used to delete the branches that have already been landed.

_Example:_
```
   cmk GhostBranch
   git branch -D GhostBranch
```
At this point `GhostBranch` is no longer valid, however, there's still a lingering record of it.

So now we can:

```
   ccb
```

This will delete `GhostBranch` but keep any other valid branches intact.

There's also an `--archive` parameter which cause clean up to archive instead of delete the branches.

**2) Delete archived branches**

Deletes all childless archived branches.

