### PR TITLE
Update print_child_branch_structure.py to support python 3.7

### DIFF
--- a/src/subcommands/print_child_branch_structure.py
+++ b/src/subcommands/print_child_branch_structure.py
@@ -106,7 +106,12 @@ def format_node(current_branch, node):
 def sorted_look_ahead(iterable):
     # type: (Iterable[T]) -> Iterable[Tuple[T, bool]]
     it = iter(sorted(iterable))
-    last = next(it)
+
+    try:
+        last = next(it)
+    except StopIteration:
+        return
+
     for val in it:
         yield last, False
         last = val


### PR DESCRIPTION
Fix “RuntimeError: generator raised StopIteration” in python 3.7

> PEP 479 is enabled for all code in Python 3.7, meaning that StopIteration exceptions raised directly or indirectly in coroutines and generators are transformed into RuntimeError exceptions. (Contributed by Yury Selivanov in bpo-32670.)

https://docs.python.org/3/whatsnew/3.7.html#changes-in-python-behavior